### PR TITLE
Token Freezing + Transfer Refactors

### DIFF
--- a/contracts/Bank.sol
+++ b/contracts/Bank.sol
@@ -25,7 +25,7 @@ contract Bank is Ownable, StandaloneERC20 {
 
     struct FrozenTokens {
         uint256 amount;
-        uint256 unlockedAt;
+        uint256 frozenUntil;
     }
 
     mapping(address => uint256) private _frozenBalance;
@@ -111,7 +111,7 @@ contract Bank is Ownable, StandaloneERC20 {
 
         FrozenTokens memory frozenToken = userFrozenTokens[index];
         require(
-            frozenToken.unlockedAt <= now,
+            frozenToken.frozenUntil <= now,
             "Unable to unfreeze frozen tokens"
         );
 
@@ -142,8 +142,8 @@ contract Bank is Ownable, StandaloneERC20 {
         FrozenTokens[] memory userFrozenTokens = frozenTokens[account];
         require(index < userFrozenTokens.length, "Invalid index specified");
         uint256 amount = userFrozenTokens[index].amount;
-        uint256 unlockedAt = userFrozenTokens[index].unlockedAt;
-        return (amount, unlockedAt);
+        uint256 frozenUntil = userFrozenTokens[index].frozenUntil;
+        return (amount, frozenUntil);
     }
 
     /**

--- a/test/local/Bank.test.js
+++ b/test/local/Bank.test.js
@@ -101,7 +101,7 @@ describe('Bank', function () {
       // Fast-forward 1 block
       await time.advanceBlockTo((await this.kit.web3.eth.getBlockNumber()) + 100);
 
-      // Attempt to unfreeze the second record, which should be unlockable due to the short freeze duration
+      // Attempt to unfreeze the second record, which should be unfrozen due to the short freeze duration
       await this.bank.unfreezeTokens(this.vaultInstance.address, 1);
 
       const currentFrozenBalance = new BigNumber(await this.bank.frozenBalanceOf(this.vaultInstance.address));
@@ -146,7 +146,7 @@ describe('Bank', function () {
     });
 
     it('should not allow a owners to unfreeze tokens when not yet available', function () {
-      // Attempt to unfreeze the first record, which should not be unlockable yet
+      // Attempt to unfreeze the first record, which should not be unfrozen yet
       return assert.isRejected(this.bank.unfreezeTokens(this.vaultInstance.address, 0));
     });
 


### PR DESCRIPTION
## Changes
- Updated `seed` to consider the `seedRatio` when minting tokens.
- Updated `seed` to also immediately freeze newly minted tokens based on the currently set parameters (No auto-lock for the CELO yet, to be done in the next PR)
- Overridden inherited `transfer` and `transferFrom` methods to make sure calls to these methods also covers validation against our freezing and locking mechanism on tokens.
- Added `transferFromVault` as a convenience method for vault owners to transfer his/her tokens without the need of setting allowances.
- Updated tests based on changes above.