### PR TITLE
Bank CELO Lock and Account Registration

### DIFF
--- a/migrations/4_initialize_contracts.js
+++ b/migrations/4_initialize_contracts.js
@@ -35,7 +35,16 @@ module.exports = (deployer) =>
       },
       {
         contract: 'Bank',
-        fn: async () => await bank.initialize(tokenName, tokenSymbol, tokenDecimal, [], [], seedFreezeDuration)
+        fn: async () =>
+          await bank.initializeBank(
+            tokenName,
+            tokenSymbol,
+            tokenDecimal,
+            [],
+            [],
+            seedFreezeDuration,
+            registryContractAddress
+          )
       },
       {
         contract: 'Portfolio',


### PR DESCRIPTION
## Changes
- Refactor `Bank` contract initializer and rename it to `initializeBank` due to overloading clash (no 2 functions with identical number of params) with `OZ`'s Standalone `ERC20`.
- Automatically register `Bank` upon initialization, as well as locking incoming `CELO` from `seed`.